### PR TITLE
Enable deployment to named IIS websites

### DIFF
--- a/src/WebDeploy/Deploy/WebDeployManager.cs
+++ b/src/WebDeploy/Deploy/WebDeployManager.cs
@@ -106,6 +106,13 @@ namespace Cake.WebDeploy
                         destPath += "/" + settings.DestinationPath.FullPath;
                     }
                 }
+                //When a SiteName is given but no DestinationPath
+                else if (!String.IsNullOrWhiteSpace(settings.SiteName))
+                {
+                    //use ContentPath so it gets deployed to the Path of the named website in IIS
+                    //which is the same behaviour as in Visual Studio
+                    destProvider = DeploymentWellKnownProvider.ContentPath;
+                }
 
 
 


### PR DESCRIPTION
Previously, when you tried to deploy using a SiteName but no DestinationPath, it would assume the sourcePath as the destinationPath.

For example, if you had your files in `E:\awesome\Website` and deploy using the SiteName `AwesomeWebsite`, which is a configured Website on the destination machine to `C:\inetpub\wwwroot\AwesomeWebsite`, it would try to deploy to `E:\awesome\Website` on the remote  machine which probably isn't what the user expected.
Now when using `DeploymentWellKnownProvider.ContentPath`, it will use the path configured in IIS for this Website instead.

This behaviour matches Visual Studio's and also enables features such as the Automatic Backup feature of WebDeploy.
