### PR TITLE
Change UseSiteName to fill the property SiteName

### DIFF
--- a/src/WebDeploy/Extensions/DeploySettingsExtensions.cs
+++ b/src/WebDeploy/Extensions/DeploySettingsExtensions.cs
@@ -129,7 +129,7 @@ namespace Cake.WebDeploy
                 throw new ArgumentNullException("settings");
             }
 
-            settings.ComputerName = name;
+            settings.SiteName = name;
             return settings;
         }
 


### PR DESCRIPTION
This function filled the `ComputerName` instead of the `SiteName`. It's a minor bug but one that did took a few seconds to find it. 

No unittest was added
