### PR TITLE
Feature/add parameters

### DIFF
--- a/src/WebDeploy.Tests/Cake.WebDeploy.Tests.csproj
+++ b/src/WebDeploy.Tests/Cake.WebDeploy.Tests.csproj
@@ -51,6 +51,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Xml" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
     </Reference>

--- a/src/WebDeploy/Deploy/WebDeployManager.cs
+++ b/src/WebDeploy/Deploy/WebDeployManager.cs
@@ -149,6 +149,11 @@ namespace Cake.WebDeploy
 
                 using (var deploymentObject = DeploymentManager.CreateObject(sourceProvider, sourcePath.FullPath, sourceOptions))
                 {
+                    foreach (var kv in settings.Parameters)
+                    {
+                        deploymentObject.SyncParameters[kv.Key].Value = kv.Value;
+                    }
+
                     return deploymentObject.SyncTo(destProvider, destPath, destOptions, syncOptions);
                 }
             }
@@ -187,11 +192,11 @@ namespace Cake.WebDeploy
                     case TraceLevel.Warning:
                         _Log.Warning(e.Message);
                         break;
-                        
+
                     case TraceLevel.Info:
                         _Log.Information(e.Message);
                         break;
-                        
+
                     case TraceLevel.Verbose:
                         _Log.Verbose(e.Message);
                         break;

--- a/src/WebDeploy/Extensions/DeploySettingsExtensions.cs
+++ b/src/WebDeploy/Extensions/DeploySettingsExtensions.cs
@@ -168,7 +168,7 @@ namespace Cake.WebDeploy
             settings.Password = password;
             return settings;
         }
-        
+
 
 
         /// <summary>
@@ -254,6 +254,24 @@ namespace Cake.WebDeploy
             }
 
             settings.DestinationPath = path;
+            return settings;
+        }
+
+        /// <summary>
+        /// Adds the parameter.
+        /// </summary>
+        /// <param name="settings">The publish settings.</param>
+        /// <param name="key">The key.</param>
+        /// <param name="value">The value.</param>
+        /// <returns>The same <see cref="DeploySettings"/> instance so that multiple calls can be chained.</returns>
+        public static DeploySettings AddParameter(this DeploySettings settings, string key, string value)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
+            settings.Parameters[key] = value;
             return settings;
         }
 

--- a/src/WebDeploy/Settings/DeploySettings.cs
+++ b/src/WebDeploy/Settings/DeploySettings.cs
@@ -1,5 +1,6 @@
 ﻿#region Using Statements
     using System;
+    using System.Collections.Generic;
     using System.Diagnostics;
 
     using Cake.Core.IO;
@@ -14,7 +15,7 @@ namespace Cake.WebDeploy
     /// </summary>
     public class DeploySettings
     {
-        #region Fields (9)
+        #region Fields (10)
             private string _PublishUrl = "";
             private RemoteAgent _AgentType = RemoteAgent.None;
             private bool? _NTLM = null;
@@ -33,6 +34,7 @@ namespace Cake.WebDeploy
 
             private FilePath _SourcePath;
             private FilePath _DestinationPath;
+            private Dictionary<string, string> _Parameters;
         #endregion
 
 
@@ -63,6 +65,7 @@ namespace Cake.WebDeploy
 
                 _SourcePath = null;
                 _DestinationPath = null;
+                _Parameters = new Dictionary<string, string>();
             }
         #endregion
 
@@ -70,7 +73,7 @@ namespace Cake.WebDeploy
 
 
 
-        #region Properties (10)
+        #region Properties (11)
             /// <summary>
             /// Gets or sets the url to publish that package to
             /// </summary>
@@ -312,6 +315,11 @@ namespace Cake.WebDeploy
                     _DestinationPath = value;
                 }
             }
+
+        public Dictionary<string, string> Parameters
+        {
+            get { return _Parameters; }
+        }
         #endregion
     }
 }


### PR DESCRIPTION
Add ability to set/override syncparameters

Sync parameters are used to sync the parameters on the server. However
there was no way to override those. The functionality added allows the
user to override those commands.

By using the following command in cake you can deploy to another site or
use another connection string.

```
setting.AddParameter("IIS Web Application Name", "another site");
```
