### PR TITLE
Added ability to add SkipRules

### DIFF
--- a/src/WebDeploy/Cake.WebDeploy.csproj
+++ b/src/WebDeploy/Cake.WebDeploy.csproj
@@ -54,10 +54,11 @@
     <Compile Include="Extensions\DeploySettingsExtensions.cs" />
     <Compile Include="Interfaces\IWebDeployManager.cs" />
     <Compile Include="Settings\DeploySettings.cs" />
+    <Compile Include="Settings\SkipRule.cs" />
     <Compile Include="Settings\RemoteAgent.cs" />
-	<Compile Include="Properties\Namespaces.cs" />
-	<Compile Include="Properties\AssemblyInfo.cs" />
-	<Compile Include="..\SolutionInfo.cs">
+    <Compile Include="Properties\Namespaces.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="..\SolutionInfo.cs">
       <Link>Properties\SolutionInfo.cs</Link>
     </Compile>
   </ItemGroup>

--- a/src/WebDeploy/Deploy/WebDeployManager.cs
+++ b/src/WebDeploy/Deploy/WebDeployManager.cs
@@ -138,7 +138,11 @@ namespace Cake.WebDeploy
                     WhatIf = settings.WhatIf
                 };
 
-
+                // Add SkipRules 
+                foreach (var rule in settings.SkipRules)
+                {
+                    syncOptions.Rules.Add(new DeploymentSkipRule(rule.Name, rule.SkipAction, rule.ObjectName, rule.AbsolutePath, rule.XPath));
+                }
 
                 //Deploy
                 _Log.Debug(Verbosity.Normal, "Deploying Website...");

--- a/src/WebDeploy/Extensions/DeploySettingsExtensions.cs
+++ b/src/WebDeploy/Extensions/DeploySettingsExtensions.cs
@@ -1,6 +1,6 @@
 ﻿#region Using Statements
-    using System;
-    using System.Diagnostics;
+using System;
+using System.Diagnostics;
 #endregion
 
 
@@ -272,6 +272,44 @@ namespace Cake.WebDeploy
             }
 
             settings.Parameters[key] = value;
+            return settings;
+        }
+
+        /// <summary>
+        /// Adds a <see cref="SkipRule" />.
+        /// </summary>
+        /// <param name="settings">The publish settings.</param>
+        /// <param name="rule">The rule.</param>
+        /// <returns>The same <see cref="DeploySettings"/> instance so that multiple calls can be chained.</returns>
+        public static DeploySettings AddSkipRule(this DeploySettings settings, SkipRule rule)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
+            settings.SkipRules.Add(rule);
+            return settings;
+        }
+
+        /// <summary>
+        /// Adds a <see cref="SkipRule" />.
+        /// </summary>
+        /// <param name="settings">The publish settings.</param>
+        /// <param name="name">The name.</param>
+        /// <param name="skipAction">The skipAction.</param>
+        /// <param name="objectName">The objectName.</param>
+        /// <param name="absolutePath">The absolutePath.</param>
+        /// <param name="xpath">The xpath.</param>
+        /// <returns>The same <see cref="DeploySettings"/> instance so that multiple calls can be chained.</returns>
+        public static DeploySettings AddSkipRule(this DeploySettings settings, string name, string skipAction, string objectName, string absolutePath, string xpath = null)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException("settings");
+            }
+
+            settings.SkipRules.Add(new SkipRule(name, skipAction, objectName, absolutePath, xpath));
             return settings;
         }
 

--- a/src/WebDeploy/Extensions/DeploySettingsExtensions.cs
+++ b/src/WebDeploy/Extensions/DeploySettingsExtensions.cs
@@ -1,6 +1,6 @@
 ﻿#region Using Statements
-using System;
-using System.Diagnostics;
+    using System;
+    using System.Diagnostics;
 #endregion
 
 

--- a/src/WebDeploy/Settings/DeploySettings.cs
+++ b/src/WebDeploy/Settings/DeploySettings.cs
@@ -1,9 +1,9 @@
 ﻿#region Using Statements
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
 
-using Cake.Core.IO;
+    using Cake.Core.IO;
 #endregion
 
 
@@ -16,26 +16,26 @@ namespace Cake.WebDeploy
     public class DeploySettings
     {
         #region Fields (16)
-        private string _PublishUrl = "";
-        private RemoteAgent _AgentType = RemoteAgent.None;
-        private bool? _NTLM = null;
-        private bool _AllowUntrusted;
+            private string _PublishUrl = "";
+            private RemoteAgent _AgentType = RemoteAgent.None;
+            private bool? _NTLM = null;
+            private bool _AllowUntrusted;
 
-        private string _ComputerName = "";
-        private int _Port;
-        private string _SiteName = "";
+            private string _ComputerName = "";
+            private int _Port;
+            private string _SiteName = "";
 
-        private string _Username = "";
-        private string _Password = "";
+            private string _Username = "";
+            private string _Password = "";
 
-        private TraceLevel _TraceLevel;
-        private bool _Delete;
-        private bool _WhatIf;
+            private TraceLevel _TraceLevel;
+            private bool _Delete;
+            private bool _WhatIf;
 
-        private FilePath _SourcePath;
-        private FilePath _DestinationPath;
-        private Dictionary<string, string> _Parameters;
-        private List<SkipRule> _DeploymentSkipRules;
+            private FilePath _SourcePath;
+            private FilePath _DestinationPath;
+            private Dictionary<string, string> _Parameters;
+            private List<SkipRule> _DeploymentSkipRules;
         #endregion
 
 
@@ -43,32 +43,32 @@ namespace Cake.WebDeploy
 
 
         #region Constructor (1)
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DeploySettings" /> class.
-        /// </summary>
-        public DeploySettings()
-        {
-            _PublishUrl = "";
-            _AgentType = RemoteAgent.None;
-            _NTLM = null;
-            _AllowUntrusted = true;
+            /// <summary>
+            /// Initializes a new instance of the <see cref="DeploySettings" /> class.
+            /// </summary>
+            public DeploySettings()
+            {
+                _PublishUrl = "";
+                _AgentType = RemoteAgent.None;
+                _NTLM = null;
+                _AllowUntrusted = true;
 
-            _ComputerName = "localhost";
-            _Port = DeployUtils.DefaultPort;
-            _SiteName = "";
+                _ComputerName = "localhost";
+                _Port = DeployUtils.DefaultPort;
+                _SiteName = "";
 
-            _Username = "";
-            _Password = "";
+                _Username = "";
+                _Password = "";
 
-            _TraceLevel = TraceLevel.Info;
-            _Delete = true;
-            _WhatIf = false;
+                _TraceLevel = TraceLevel.Info;
+                _Delete = true;
+                _WhatIf = false;
 
-            _SourcePath = null;
-            _DestinationPath = null;
-            _Parameters = new Dictionary<string, string>();
-            _DeploymentSkipRules = new List<SkipRule>();
-        }
+                _SourcePath = null;
+                _DestinationPath = null;
+                _Parameters = new Dictionary<string, string>();
+                _DeploymentSkipRules = new List<SkipRule>();
+            }
         #endregion
 
 
@@ -76,263 +76,263 @@ namespace Cake.WebDeploy
 
 
         #region Properties (16)
-        /// <summary>
-        /// Gets or sets the url to publish that package to
-        /// </summary>
-        public string PublishUrl
-        {
-            get
+            /// <summary>
+            /// Gets or sets the url to publish that package to
+            /// </summary>
+            public string PublishUrl
             {
-                if (!String.IsNullOrEmpty(_PublishUrl))
+                get
                 {
-                    return _PublishUrl;
-                }
-                else
-                {
-                    if ((_AgentType == RemoteAgent.WMSvc) || (_AgentType == RemoteAgent.None))
+                    if (!String.IsNullOrEmpty(_PublishUrl))
                     {
-                        return DeployUtils.GetWmsvcUrl(_ComputerName, _Port, _SiteName);
+                        return _PublishUrl;
                     }
                     else
                     {
-                        return _ComputerName;
+                        if ((_AgentType == RemoteAgent.WMSvc) || (_AgentType == RemoteAgent.None))
+                        {
+                            return DeployUtils.GetWmsvcUrl(_ComputerName, _Port, _SiteName);
+                        }
+                        else
+                        {
+                            return _ComputerName;
+                        }
                     }
                 }
-            }
-            set
-            {
-                _PublishUrl = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the type of remote agent to connect to
-        /// </summary>
-        public RemoteAgent AgentType
-        {
-            get
-            {
-                return _AgentType;
-            }
-            set
-            {
-                _AgentType = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets if NTLM authentication should be used
-        /// </summary>
-        public bool NTLM
-        {
-            get
-            {
-
-                if (!_NTLM.HasValue)
+                set
                 {
-                    if ((_AgentType == RemoteAgent.WMSvc) || (_AgentType == RemoteAgent.None))
-                    {
-                        return false;
-                    }
-                    else
-                    {
-                        return true;
-                    }
+                    _PublishUrl = value;
                 }
+            }
 
-                return _NTLM.Value;
-            }
-            set
+            /// <summary>
+            /// Gets or sets the type of remote agent to connect to
+            /// </summary>
+            public RemoteAgent AgentType
             {
-                _NTLM = value;
+                get
+                {
+                    return _AgentType;
+                }
+                set
+                {
+                    _AgentType = value;
+                }
             }
-        }
 
-        /// <summary>
-        /// Gets or sets if untrusted certificates should be allowed
-        /// </summary>
-        public bool AllowUntrusted
-        {
-            get
+            /// <summary>
+            /// Gets or sets if NTLM authentication should be used
+            /// </summary>
+            public bool NTLM
             {
-                return _AllowUntrusted;
-            }
-            set
-            {
-                _AllowUntrusted = value;
-            }
-        }
+                get
+                {
 
+                    if (!_NTLM.HasValue)
+                    {
+                        if ((_AgentType == RemoteAgent.WMSvc) || (_AgentType == RemoteAgent.None))
+                        {
+                            return false;
+                        }
+                        else
+                        {
+                            return true;
+                        }
+                    }
 
-        /// <summary>
-        /// Gets or sets the computer name to publish to
-        /// </summary>
-        public string ComputerName
-        {
-            get
-            {
-                return _ComputerName;
+                    return _NTLM.Value;
+                }
+                set
+                {
+                    _NTLM = value;
+                }
             }
-            set
-            {
-                _ComputerName = value;
-            }
-        }
 
-        /// <summary>
-        /// Sets the remote port to connect on
-        /// </summary>
-        public int Port
-        {
-            get
+            /// <summary>
+            /// Gets or sets if untrusted certificates should be allowed
+            /// </summary>
+            public bool AllowUntrusted
             {
-                return _Port;
+                get
+                {
+                    return _AllowUntrusted;
+                }
+                set
+                {
+                    _AllowUntrusted = value;
+                }
             }
-            set
-            {
-                _Port = value;
-            }
-        }
-
-        /// <summary>
-        /// Sets the name of the website to publish
-        /// </summary>
-        public string SiteName
-        {
-            get
-            {
-                return _SiteName;
-            }
-            set
-            {
-                _SiteName = value;
-            }
-        }
 
 
-        /// <summary>
-        /// Gets or sets the credentials to use when connecting
-        /// </summary>
-        public string Username
-        {
-            get
+            /// <summary>
+            /// Gets or sets the computer name to publish to
+            /// </summary>
+            public string ComputerName
             {
-                return _Username;
+                get
+                {
+                    return _ComputerName;
+                }
+                set
+                {
+                    _ComputerName = value;
+                }
             }
-            set
-            {
-                _Username = value;
-            }
-        }
 
-        /// <summary>
-        /// Gets or sets the credentials to use when connecting
-        /// </summary>
-        public string Password
-        {
-            get
+            /// <summary>
+            /// Sets the remote port to connect on
+            /// </summary>
+            public int Port
             {
-                return _Password;
+                get
+                {
+                    return _Port;
+                }
+                set
+                {
+                    _Port = value;
+                }
             }
-            set
-            {
-                _Password = value;
-            }
-        }
 
-
-        /// <summary>
-        /// Gets or sets the logging trace level
-        /// </summary>
-        public TraceLevel TraceLevel
-        {
-            get
+            /// <summary>
+            /// Sets the name of the website to publish
+            /// </summary>
+            public string SiteName
             {
-                return _TraceLevel;
+                get
+                {
+                    return _SiteName;
+                }
+                set
+                {
+                    _SiteName = value;
+                }
             }
-            set
-            {
-                _TraceLevel = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets if files that no longer exist should be deleted
-        /// </summary>
-        public bool Delete
-        {
-            get
-            {
-                return _Delete;
-            }
-            set
-            {
-                _Delete = value;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets if operations will not be executed but events will still be fired
-        /// </summary>
-        public bool WhatIf
-        {
-            get
-            {
-                return _WhatIf;
-            }
-            set
-            {
-                _WhatIf = value;
-            }
-        }
 
 
-
-        /// <summary>
-        /// Gets or sets the source of the package to publish
-        /// </summary>
-        public FilePath SourcePath
-        {
-            get
+            /// <summary>
+            /// Gets or sets the credentials to use when connecting
+            /// </summary>
+            public string Username
             {
-                return _SourcePath;
+                get
+                {
+                    return _Username;
+                }
+                set
+                {
+                    _Username = value;
+                }
             }
-            set
-            {
-                _SourcePath = value;
-            }
-        }
 
-        /// <summary>
-        /// Gets or sets the destination of the package to publish to
-        /// </summary>
-        public FilePath DestinationPath
-        {
-            get
+            /// <summary>
+            /// Gets or sets the credentials to use when connecting
+            /// </summary>
+            public string Password
             {
-                return _DestinationPath;
+                get
+                {
+                    return _Password;
+                }
+                set
+                {
+                    _Password = value;
+                }
             }
-            set
+
+
+            /// <summary>
+            /// Gets or sets the logging trace level
+            /// </summary>
+            public TraceLevel TraceLevel
             {
-                _DestinationPath = value;
+                get
+                {
+                    return _TraceLevel;
+                }
+                set
+                {
+                    _TraceLevel = value;
+                }
             }
-        }
 
-        /// <summary>
-        /// Gets or sets the <see cref="Parameters" />.
-        /// </summary>
-        public Dictionary<string, string> Parameters
-        {
-            get { return _Parameters; }
-        }
+            /// <summary>
+            /// Gets or sets if files that no longer exist should be deleted
+            /// </summary>
+            public bool Delete
+            {
+                get
+                {
+                    return _Delete;
+                }
+                set
+                {
+                    _Delete = value;
+                }
+            }
 
-        /// <summary>
-        /// Gets or sets the <see cref="SkipRules" />.
-        /// </summary>
-        public List<SkipRule> SkipRules
-        {
-            get { return _DeploymentSkipRules; }
-        }
+            /// <summary>
+            /// Gets or sets if operations will not be executed but events will still be fired
+            /// </summary>
+            public bool WhatIf
+            {
+                get
+                {
+                    return _WhatIf;
+                }
+                set
+                {
+                    _WhatIf = value;
+                }
+            }
+
+
+
+            /// <summary>
+            /// Gets or sets the source of the package to publish
+            /// </summary>
+            public FilePath SourcePath
+            {
+                get
+                {
+                    return _SourcePath;
+                }
+                set
+                {
+                    _SourcePath = value;
+                }
+            }
+
+            /// <summary>
+            /// Gets or sets the destination of the package to publish to
+            /// </summary>
+            public FilePath DestinationPath
+            {
+                get
+                {
+                    return _DestinationPath;
+                }
+                set
+                {
+                    _DestinationPath = value;
+                }
+            }
+
+            /// <summary>
+            /// Gets or sets the <see cref="Parameters" />.
+            /// </summary>
+            public Dictionary<string, string> Parameters
+            {
+                get { return _Parameters; }
+            }
+
+            /// <summary>
+            /// Gets or sets the <see cref="SkipRules" />.
+            /// </summary>
+            public List<SkipRule> SkipRules
+            {
+                get { return _DeploymentSkipRules; }
+            }
         #endregion
     }
 }

--- a/src/WebDeploy/Settings/DeploySettings.cs
+++ b/src/WebDeploy/Settings/DeploySettings.cs
@@ -1,9 +1,9 @@
 ﻿#region Using Statements
-    using System;
-    using System.Collections.Generic;
-    using System.Diagnostics;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 
-    using Cake.Core.IO;
+using Cake.Core.IO;
 #endregion
 
 
@@ -15,26 +15,27 @@ namespace Cake.WebDeploy
     /// </summary>
     public class DeploySettings
     {
-        #region Fields (10)
-            private string _PublishUrl = "";
-            private RemoteAgent _AgentType = RemoteAgent.None;
-            private bool? _NTLM = null;
-            private bool _AllowUntrusted;
+        #region Fields (16)
+        private string _PublishUrl = "";
+        private RemoteAgent _AgentType = RemoteAgent.None;
+        private bool? _NTLM = null;
+        private bool _AllowUntrusted;
 
-            private string _ComputerName = "";
-            private int _Port;
-            private string _SiteName = "";
+        private string _ComputerName = "";
+        private int _Port;
+        private string _SiteName = "";
 
-            private string _Username = "";
-            private string _Password = "";
+        private string _Username = "";
+        private string _Password = "";
 
-            private TraceLevel _TraceLevel;
-            private bool _Delete;
-            private bool _WhatIf;
+        private TraceLevel _TraceLevel;
+        private bool _Delete;
+        private bool _WhatIf;
 
-            private FilePath _SourcePath;
-            private FilePath _DestinationPath;
-            private Dictionary<string, string> _Parameters;
+        private FilePath _SourcePath;
+        private FilePath _DestinationPath;
+        private Dictionary<string, string> _Parameters;
+        private List<SkipRule> _DeploymentSkipRules;
         #endregion
 
 
@@ -42,283 +43,295 @@ namespace Cake.WebDeploy
 
 
         #region Constructor (1)
-            /// <summary>
-            /// Initializes a new instance of the <see cref="DeploySettings" /> class.
-            /// </summary>
-            public DeploySettings()
-            {
-                _PublishUrl = "";
-                _AgentType = RemoteAgent.None;
-                _NTLM = null;
-                _AllowUntrusted = true;
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeploySettings" /> class.
+        /// </summary>
+        public DeploySettings()
+        {
+            _PublishUrl = "";
+            _AgentType = RemoteAgent.None;
+            _NTLM = null;
+            _AllowUntrusted = true;
 
-                _ComputerName = "localhost";
-                _Port = DeployUtils.DefaultPort;
-                _SiteName = "";
+            _ComputerName = "localhost";
+            _Port = DeployUtils.DefaultPort;
+            _SiteName = "";
 
-                _Username = "";
-                _Password = "";
+            _Username = "";
+            _Password = "";
 
-                _TraceLevel = TraceLevel.Info;
-                _Delete = true;
-                _WhatIf = false;
+            _TraceLevel = TraceLevel.Info;
+            _Delete = true;
+            _WhatIf = false;
 
-                _SourcePath = null;
-                _DestinationPath = null;
-                _Parameters = new Dictionary<string, string>();
-            }
+            _SourcePath = null;
+            _DestinationPath = null;
+            _Parameters = new Dictionary<string, string>();
+            _DeploymentSkipRules = new List<SkipRule>();
+        }
         #endregion
 
 
 
 
 
-        #region Properties (11)
-            /// <summary>
-            /// Gets or sets the url to publish that package to
-            /// </summary>
-            public string PublishUrl
+        #region Properties (16)
+        /// <summary>
+        /// Gets or sets the url to publish that package to
+        /// </summary>
+        public string PublishUrl
+        {
+            get
             {
-                get
+                if (!String.IsNullOrEmpty(_PublishUrl))
                 {
-                    if (!String.IsNullOrEmpty(_PublishUrl))
+                    return _PublishUrl;
+                }
+                else
+                {
+                    if ((_AgentType == RemoteAgent.WMSvc) || (_AgentType == RemoteAgent.None))
                     {
-                        return _PublishUrl;
+                        return DeployUtils.GetWmsvcUrl(_ComputerName, _Port, _SiteName);
                     }
                     else
                     {
-                        if ((_AgentType == RemoteAgent.WMSvc) || (_AgentType == RemoteAgent.None))
-                        {
-                            return DeployUtils.GetWmsvcUrl(_ComputerName, _Port, _SiteName);
-                        }
-                        else
-                        {
-                            return _ComputerName;
-                        }
+                        return _ComputerName;
                     }
                 }
-                set
-                {
-                    _PublishUrl = value;
-                }
             }
-
-            /// <summary>
-            /// Gets or sets the type of remote agent to connect to
-            /// </summary>
-            public RemoteAgent AgentType
+            set
             {
-                get
-                {
-                    return _AgentType;
-                }
-                set
-                {
-                    _AgentType = value;
-                }
+                _PublishUrl = value;
             }
+        }
 
-            /// <summary>
-            /// Gets or sets if NTLM authentication should be used
-            /// </summary>
-            public bool NTLM
+        /// <summary>
+        /// Gets or sets the type of remote agent to connect to
+        /// </summary>
+        public RemoteAgent AgentType
+        {
+            get
             {
-                get
-                {
+                return _AgentType;
+            }
+            set
+            {
+                _AgentType = value;
+            }
+        }
 
-                    if (!_NTLM.HasValue)
+        /// <summary>
+        /// Gets or sets if NTLM authentication should be used
+        /// </summary>
+        public bool NTLM
+        {
+            get
+            {
+
+                if (!_NTLM.HasValue)
+                {
+                    if ((_AgentType == RemoteAgent.WMSvc) || (_AgentType == RemoteAgent.None))
                     {
-                        if ((_AgentType == RemoteAgent.WMSvc) || (_AgentType == RemoteAgent.None))
-                        {
-                            return false;
-                        }
-                        else
-                        {
-                            return true;
-                        }
+                        return false;
                     }
+                    else
+                    {
+                        return true;
+                    }
+                }
 
-                    return _NTLM.Value;
-                }
-                set
-                {
-                    _NTLM = value;
-                }
+                return _NTLM.Value;
             }
-
-            /// <summary>
-            /// Gets or sets if untrusted certificates should be allowed
-            /// </summary>
-            public bool AllowUntrusted
+            set
             {
-                get
-                {
-                    return _AllowUntrusted;
-                }
-                set
-                {
-                    _AllowUntrusted = value;
-                }
+                _NTLM = value;
             }
+        }
 
-
-            /// <summary>
-            /// Gets or sets the computer name to publish to
-            /// </summary>
-            public string ComputerName
+        /// <summary>
+        /// Gets or sets if untrusted certificates should be allowed
+        /// </summary>
+        public bool AllowUntrusted
+        {
+            get
             {
-                get
-                {
-                    return _ComputerName;
-                }
-                set
-                {
-                    _ComputerName = value;
-                }
+                return _AllowUntrusted;
             }
-
-            /// <summary>
-            /// Sets the remote port to connect on
-            /// </summary>
-            public int Port
+            set
             {
-                get
-                {
-                    return _Port;
-                }
-                set
-                {
-                    _Port = value;
-                }
+                _AllowUntrusted = value;
             }
+        }
 
-            /// <summary>
-            /// Sets the name of the website to publish
-            /// </summary>
-            public string SiteName
+
+        /// <summary>
+        /// Gets or sets the computer name to publish to
+        /// </summary>
+        public string ComputerName
+        {
+            get
             {
-                get
-                {
-                    return _SiteName;
-                }
-                set
-                {
-                    _SiteName = value;
-                }
+                return _ComputerName;
             }
-
-
-            /// <summary>
-            /// Gets or sets the credentials to use when connecting
-            /// </summary>
-            public string Username
+            set
             {
-                get
-                {
-                    return _Username;
-                }
-                set
-                {
-                    _Username = value;
-                }
+                _ComputerName = value;
             }
+        }
 
-            /// <summary>
-            /// Gets or sets the credentials to use when connecting
-            /// </summary>
-            public string Password
+        /// <summary>
+        /// Sets the remote port to connect on
+        /// </summary>
+        public int Port
+        {
+            get
             {
-                get
-                {
-                    return _Password;
-                }
-                set
-                {
-                    _Password = value;
-                }
+                return _Port;
             }
-
-
-            /// <summary>
-            /// Gets or sets the logging trace level
-            /// </summary>
-            public TraceLevel TraceLevel
+            set
             {
-                get
-                {
-                    return _TraceLevel;
-                }
-                set
-                {
-                    _TraceLevel = value;
-                }
+                _Port = value;
             }
+        }
 
-            /// <summary>
-            /// Gets or sets if files that no longer exist should be deleted
-            /// </summary>
-            public bool Delete
+        /// <summary>
+        /// Sets the name of the website to publish
+        /// </summary>
+        public string SiteName
+        {
+            get
             {
-                get
-                {
-                    return _Delete;
-                }
-                set
-                {
-                    _Delete = value;
-                }
+                return _SiteName;
             }
-
-            /// <summary>
-            /// Gets or sets if operations will not be executed but events will still be fired
-            /// </summary>
-            public bool WhatIf
+            set
             {
-                get
-                {
-                    return _WhatIf;
-                }
-                set
-                {
-                    _WhatIf = value;
-                }
+                _SiteName = value;
             }
+        }
 
 
-
-            /// <summary>
-            /// Gets or sets the source of the package to publish
-            /// </summary>
-            public FilePath SourcePath
+        /// <summary>
+        /// Gets or sets the credentials to use when connecting
+        /// </summary>
+        public string Username
+        {
+            get
             {
-                get
-                {
-                    return _SourcePath;
-                }
-                set
-                {
-                    _SourcePath = value;
-                }
+                return _Username;
             }
-
-            /// <summary>
-            /// Gets or sets the destination of the package to publish to
-            /// </summary>
-            public FilePath DestinationPath
+            set
             {
-                get
-                {
-                    return _DestinationPath;
-                }
-                set
-                {
-                    _DestinationPath = value;
-                }
+                _Username = value;
             }
+        }
 
+        /// <summary>
+        /// Gets or sets the credentials to use when connecting
+        /// </summary>
+        public string Password
+        {
+            get
+            {
+                return _Password;
+            }
+            set
+            {
+                _Password = value;
+            }
+        }
+
+
+        /// <summary>
+        /// Gets or sets the logging trace level
+        /// </summary>
+        public TraceLevel TraceLevel
+        {
+            get
+            {
+                return _TraceLevel;
+            }
+            set
+            {
+                _TraceLevel = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets if files that no longer exist should be deleted
+        /// </summary>
+        public bool Delete
+        {
+            get
+            {
+                return _Delete;
+            }
+            set
+            {
+                _Delete = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets if operations will not be executed but events will still be fired
+        /// </summary>
+        public bool WhatIf
+        {
+            get
+            {
+                return _WhatIf;
+            }
+            set
+            {
+                _WhatIf = value;
+            }
+        }
+
+
+
+        /// <summary>
+        /// Gets or sets the source of the package to publish
+        /// </summary>
+        public FilePath SourcePath
+        {
+            get
+            {
+                return _SourcePath;
+            }
+            set
+            {
+                _SourcePath = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the destination of the package to publish to
+        /// </summary>
+        public FilePath DestinationPath
+        {
+            get
+            {
+                return _DestinationPath;
+            }
+            set
+            {
+                _DestinationPath = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the <see cref="Parameters" />.
+        /// </summary>
         public Dictionary<string, string> Parameters
         {
             get { return _Parameters; }
+        }
+
+        /// <summary>
+        /// Gets or sets the <see cref="SkipRules" />.
+        /// </summary>
+        public List<SkipRule> SkipRules
+        {
+            get { return _DeploymentSkipRules; }
         }
         #endregion
     }

--- a/src/WebDeploy/Settings/SkipRule.cs
+++ b/src/WebDeploy/Settings/SkipRule.cs
@@ -1,0 +1,61 @@
+﻿#region Using Statements
+using System;
+#endregion
+
+namespace Cake.WebDeploy
+{
+    public class SkipRule
+    {
+        #region Constructor (2)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SkipRule" /> class.
+        /// </summary>
+        public SkipRule()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SkipRule" /> class.
+        /// </summary>
+        public SkipRule(string name, string skipAction, string objectName, string absolutePath, string xpath = null)
+        {
+            Name = name;
+            SkipAction = skipAction;
+            ObjectName = objectName;
+            AbsolutePath = absolutePath;
+            XPath = xpath;
+        }
+        #endregion
+
+
+
+
+
+        #region Properties (5)
+        /// <summary>
+        /// Gets or sets the Name.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the SkipAction.
+        /// </summary>
+        public string SkipAction { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ObjectName.
+        /// </summary>
+        public string ObjectName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the AbsolutePath.
+        /// </summary>
+        public string AbsolutePath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the XPath.
+        /// </summary>
+        public string XPath { get; set; }
+        #endregion
+    }
+}

--- a/src/WebDeploy/Settings/SkipRule.cs
+++ b/src/WebDeploy/Settings/SkipRule.cs
@@ -1,5 +1,5 @@
 ﻿#region Using Statements
-using System;
+    using System;
 #endregion
 
 namespace Cake.WebDeploy
@@ -7,24 +7,24 @@ namespace Cake.WebDeploy
     public class SkipRule
     {
         #region Constructor (2)
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SkipRule" /> class.
-        /// </summary>
-        public SkipRule()
-        {
-        }
+            /// <summary>
+            /// Initializes a new instance of the <see cref="SkipRule" /> class.
+            /// </summary>
+            public SkipRule()
+            {
+            }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SkipRule" /> class.
-        /// </summary>
-        public SkipRule(string name, string skipAction, string objectName, string absolutePath, string xpath = null)
-        {
-            Name = name;
-            SkipAction = skipAction;
-            ObjectName = objectName;
-            AbsolutePath = absolutePath;
-            XPath = xpath;
-        }
+            /// <summary>
+            /// Initializes a new instance of the <see cref="SkipRule" /> class.
+            /// </summary>
+            public SkipRule(string name, string skipAction, string objectName, string absolutePath, string xpath = null)
+            {
+                Name = name;
+                SkipAction = skipAction;
+                ObjectName = objectName;
+                AbsolutePath = absolutePath;
+                XPath = xpath;
+            }
         #endregion
 
 
@@ -32,30 +32,30 @@ namespace Cake.WebDeploy
 
 
         #region Properties (5)
-        /// <summary>
-        /// Gets or sets the Name.
-        /// </summary>
-        public string Name { get; set; }
+            /// <summary>
+            /// Gets or sets the Name.
+            /// </summary>
+            public string Name { get; set; }
 
-        /// <summary>
-        /// Gets or sets the SkipAction.
-        /// </summary>
-        public string SkipAction { get; set; }
+            /// <summary>
+            /// Gets or sets the SkipAction.
+            /// </summary>
+            public string SkipAction { get; set; }
 
-        /// <summary>
-        /// Gets or sets the ObjectName.
-        /// </summary>
-        public string ObjectName { get; set; }
+            /// <summary>
+            /// Gets or sets the ObjectName.
+            /// </summary>
+            public string ObjectName { get; set; }
 
-        /// <summary>
-        /// Gets or sets the AbsolutePath.
-        /// </summary>
-        public string AbsolutePath { get; set; }
+            /// <summary>
+            /// Gets or sets the AbsolutePath.
+            /// </summary>
+            public string AbsolutePath { get; set; }
 
-        /// <summary>
-        /// Gets or sets the XPath.
-        /// </summary>
-        public string XPath { get; set; }
+            /// <summary>
+            /// Gets or sets the XPath.
+            /// </summary>
+            public string XPath { get; set; }
         #endregion
     }
 }


### PR DESCRIPTION
Skip rules are useful to e.g. stop web deploy from deleting/updating "App_Data" folder in the destination path.

Fluent example:

```
.AddSkipRule("SkipDeleteAppDataDir", "Delete", "dirPath", "App_Data$", null)
```
