### PR TITLE
#21 added EnableAppOffline rule

### DIFF
--- a/src/WebDeploy.Tests/Tests/WebDeployTests.cs
+++ b/src/WebDeploy.Tests/Tests/WebDeployTests.cs
@@ -93,6 +93,18 @@ namespace Cake.WebDeploy.Tests
 
             Assert.Equal(settings.PublishUrl, "https://XXX:8172/msdeploy.axd?site=Test");
         }
+
+        [Fact]
+        public void Should_Use_AppOffline()
+        {
+            DeploySettings deploySettings = new DeploySettings();
+
+            Assert.Equal(false, deploySettings.UseAppOffline);
+
+            deploySettings.UseAppOffline(true);
+
+            Assert.Equal(true, deploySettings.UseAppOffline);
+        }
         #endregion
     }
 }

--- a/src/WebDeploy/Deploy/WebDeployManager.cs
+++ b/src/WebDeploy/Deploy/WebDeployManager.cs
@@ -195,7 +195,8 @@ namespace Cake.WebDeploy
         private void AddRule(DeploymentSyncOptions syncOptions, string ruleName)
         {
             var rules = DeploymentSyncOptions.GetAvailableRules();
-            if(rules.TryGetValue(ruleName, out var newRule))
+            DeploymentRule newRule;
+            if(rules.TryGetValue(ruleName, out newRule))
             {
                 syncOptions.Rules.Add(newRule);
             }

--- a/src/WebDeploy/Deploy/WebDeployManager.cs
+++ b/src/WebDeploy/Deploy/WebDeployManager.cs
@@ -154,6 +154,8 @@ namespace Cake.WebDeploy
                 WhatIf = settings.WhatIf,
                 UseChecksum = settings.UseChecksum
             };
+            if (settings.UseAppOffline)
+                AddRule(syncOptions, "appOffline");
 
             // Add SkipRules 
             foreach (var rule in settings.SkipRules)
@@ -189,9 +191,16 @@ namespace Cake.WebDeploy
             }
         }
 
-
-
         //Helpers
+        private void AddRule(DeploymentSyncOptions syncOptions, string ruleName)
+        {
+            var rules = DeploymentSyncOptions.GetAvailableRules();
+            if(rules.TryGetValue(ruleName, out var newRule))
+            {
+                syncOptions.Rules.Add(newRule);
+            }
+        }
+
         private DeploymentBaseOptions GetBaseOptions(DeploySettings settings)
         {
             DeploymentBaseOptions options = new DeploymentBaseOptions

--- a/src/WebDeploy/Extensions/DeploySettingsExtensions.cs
+++ b/src/WebDeploy/Extensions/DeploySettingsExtensions.cs
@@ -339,6 +339,15 @@ namespace Cake.WebDeploy
             settings.UseChecksum = useChecksum;
             return settings;
         }
+
+        public static DeploySettings UseAppOffline(this DeploySettings settings, bool useAppOffline)
+        {
+            if (settings == null)
+                throw new ArgumentNullException(nameof(settings));
+
+            settings.UseAppOffline = useAppOffline;
+            return settings;
+        }
         #endregion
     }
 }

--- a/src/WebDeploy/Settings/DeploySettings.cs
+++ b/src/WebDeploy/Settings/DeploySettings.cs
@@ -374,8 +374,8 @@ namespace Cake.WebDeploy
         /// </summary>
         public bool UseAppOffline
         {
-            get => _UseAppOffline;
-            set => _UseAppOffline = value;
+            get { return _UseAppOffline; }
+            set { _UseAppOffline = value; }
         }
 
         #endregion

--- a/src/WebDeploy/Settings/DeploySettings.cs
+++ b/src/WebDeploy/Settings/DeploySettings.cs
@@ -38,6 +38,8 @@ namespace Cake.WebDeploy
         private FilePath _ParametersFilePath;
         private Dictionary<string, string> _Parameters;
         private List<SkipRule> _DeploymentSkipRules;
+        private bool _UseAppOffline;
+
         #endregion
 
 
@@ -72,11 +74,10 @@ namespace Cake.WebDeploy
             _ParametersFilePath = null;
             _Parameters = new Dictionary<string, string>();
             _DeploymentSkipRules = new List<SkipRule>();
+
+            _UseAppOffline = false;
         }
         #endregion
-
-
-
 
 
         #region Properties (16)
@@ -367,6 +368,16 @@ namespace Cake.WebDeploy
         {
             get { return _DeploymentSkipRules; }
         }
+
+        /// <summary>
+        /// Gets or sets the AppOffline rule
+        /// </summary>
+        public bool UseAppOffline
+        {
+            get => _UseAppOffline;
+            set => _UseAppOffline = value;
+        }
+
         #endregion
     }
 }


### PR DESCRIPTION
Added the ability to use the AppOffline rule so that the target web app can be put offline during the deployment process. That should help with the "fail in use" error during deployments.
Extended the `DeploySettings` with the `UseAppOffline` property as well as added a suitable extension method.