### PR TITLE
Update Cake.WebDeploy to newest Cake

### DIFF
--- a/nuspec/Cake.WebDeploy.nuspec
+++ b/nuspec/Cake.WebDeploy.nuspec
@@ -17,7 +17,7 @@
       <tags>Cake Script Build WebDeploy</tags>
 
        <dependencies>
-           <dependency id="Cake.Core" version="0.22.0" />
+           <dependency id="Cake.Core" version="0.26.1" />
        </dependencies>
    </metadata>
 

--- a/src/Cake.WebDeploy.Tests/Cake.WebDeploy.Tests.csproj
+++ b/src/Cake.WebDeploy.Tests/Cake.WebDeploy.Tests.csproj
@@ -19,8 +19,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Cake.Core" Version="0.22.0" />
-        <PackageReference Include="Cake.Testing" Version="0.22.0" />
+        <PackageReference Include="Cake.Core" Version="0.26.1" />
+        <PackageReference Include="Cake.Testing" Version="0.26.1" />
 
         <PackageReference Include="Microsoft.Web.Deployment" Version="3.6.0" />
 

--- a/src/Cake.WebDeploy/Cake.WebDeploy.csproj
+++ b/src/Cake.WebDeploy/Cake.WebDeploy.csproj
@@ -19,7 +19,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Cake.Core" Version="0.22.0" />
+        <PackageReference Include="Cake.Core" Version="0.26.1" />
 
         <PackageReference Include="Microsoft.Web.Deployment" Version="3.6.0" />
     </ItemGroup>

--- a/src/Cake.WebDeploy/Properties/SolutionInfo.cs
+++ b/src/Cake.WebDeploy/Properties/SolutionInfo.cs
@@ -5,8 +5,8 @@
 //------------------------------------------------------------------------------
 using System.Reflection;
 
-[assembly: AssemblyVersion("0.3.1")]
-[assembly: AssemblyFileVersion("0.3.1")]
-[assembly: AssemblyInformationalVersion("0.3.1")]
-[assembly: AssemblyCopyright("Copyright (c) 2015 - 2017 Phillip Sharpe")]
+[assembly: AssemblyVersion("0.3.2")]
+[assembly: AssemblyFileVersion("0.3.2")]
+[assembly: AssemblyInformationalVersion("0.3.2")]
+[assembly: AssemblyCopyright("Copyright (c) 2015 - 2018 Phillip Sharpe")]
 

--- a/src/SolutionInfo.cs
+++ b/src/SolutionInfo.cs
@@ -8,5 +8,5 @@ using System.Reflection;
 [assembly: AssemblyVersion("0.3.1")]
 [assembly: AssemblyFileVersion("0.3.1")]
 [assembly: AssemblyInformationalVersion("0.3.1")]
-[assembly: AssemblyCopyright("Copyright (c) 2015 - 2017 Phillip Sharpe")]
+[assembly: AssemblyCopyright("Copyright (c) 2015 - 2018 Phillip Sharpe")]
 


### PR DESCRIPTION
With the release of Cake 0.26.0, which upped the latest breaking change from [0.22.0 to 0.26.0](https://github.com/cake-build/cake/commit/02632b675a5f50d19231dfc33e5f003e8eb9498c#diff-85a96088153087f031e3c4fd629acc4dR11) the `Cake.WebDeploy` addin cannot be loaded unless `--settings_skipverification=true` is passed to the build script.

This commit upps the required cake version to `0.26.1`, and ups the version of `Cake.Web.Deploy` to `0.3.2`

[Release 0.26.0](https://cakebuild.net/blog/2018/02/cake-v0.26.0-released)
[Release 0.26.1](https://cakebuild.net/blog/2018/03/cake-v0.26.1-released)


